### PR TITLE
Arbitrator (Arbites) support

### DIFF
--- a/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
+++ b/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
@@ -544,11 +544,14 @@ HudElementblitzbar.init = function (self, parent, draw_layer, start_scale)
 			local replenish_grenade = (player_talents.adamant_whistle == 1) or (player_talents.adamant_disable_companion == 1)
 			local grenades_to_add = 0
 			local replenish_time = 0
+			local replenish_buff_logic = nil -- AND will accept any string, so I need this if/else up here to choose the correct replenish buff to check. otherwise it will always take the first one
 			if player_talents.adamant_disable_companion then
 				grenades_to_add = talents.adamant_disable_companion.format_values.charges.value
 				replenish_time = talents.adamant_disable_companion.format_values.time.value
+				replenish_buff_logic = replenish_grenade and "adamant_grenade_replenishment"
 			elseif whistle then
 				replenish_time = talents.adamant_whistle.format_values.cooldown.value
+				replenish_buff_logic = replenish_grenade and "adamant_whistle_replenishment"
 			end
 
 			local adamant_grenade = {
@@ -564,7 +567,7 @@ HudElementblitzbar.init = function (self, parent, draw_layer, start_scale)
 				progress = 0,
 				timed = replenish_grenade,
 				replenish = replenish_grenade,
-				replenish_buff = (replenish_grenade and "adamant_whistle_replenishment") or (replenish_grenade and "adamant_grenade_replenishment") or nil,
+				replenish_buff = replenish_buff_logic or nil,
 				damage_per_stack = nil,
 				damage_boost = nil
 			}

--- a/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
+++ b/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
@@ -527,6 +527,51 @@ HudElementblitzbar.init = function (self, parent, draw_layer, start_scale)
 		end
 	end
 
+	-- Arbitrator
+	if self._archetype_name == "adamant" then
+		-- Dog shock explosion
+		local whistle = player_talents.adamant_whistle
+		local mine = player_talents.adamant_shock_mine
+		local impact = player_talents.adamant_grenade_improved or player_talents.adamant_grenade
+
+		local grenade = (whistle	and talents.adamant_whistle) or
+						(mine		and talents.adamant_shock_mine) or
+						(impact		and (talents.adamant_grenade_improved or talents.adamant_grenade))
+
+		if grenade then
+			local grenade_ability = grenade.player_ability.ability
+			-- Shock mine replenishes naturally. Lone Wolf "keystone" gives grenade regen to all
+			local replenish_grenade = (player_talents.adamant_whistle == 1) or (player_talents.adamant_disable_companion == 1)
+			local grenades_to_add = 0
+			local replenish_time = 0
+			if player_talents.adamant_disable_companion then
+				grenades_to_add = talents.adamant_disable_companion.format_values.charges.value
+				replenish_time = talents.adamant_disable_companion.format_values.time.value
+			elseif whistle then
+				replenish_time = talents.adamant_whistle.format_values.cooldown.value
+			end
+
+			local adamant_grenade = {
+				display_name =	(whistle and 	mod.text_options["text_option_whistle"]) or
+								(mine and 		mod.text_options["text_option_mine"]) or
+												mod.text_options["text_option_adamant_grenade"],
+				max_stacks = grenade_ability.max_charges + grenades_to_add,
+				max_duration = (replenish_grenade and replenish_time) or nil,
+				decay = true,
+				grenade_ability = true,
+				stack_buff = nil,
+				stacks = 0,
+				progress = 0,
+				timed = replenish_grenade,
+				replenish = replenish_grenade,
+				replenish_buff = (replenish_grenade and "adamant_whistle_replenishment") or (replenish_grenade and "adamant_grenade_replenishment") or nil,
+				damage_per_stack = nil,
+				damage_boost = nil
+			}
+			resource_info = table.clone(adamant_grenade)
+		end
+	end
+
 	if resource_info == nil then
 		resource_info = {
 			display_name = mod.text_options["none"],

--- a/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
+++ b/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
@@ -575,6 +575,43 @@ HudElementblitzbar.init = function (self, parent, draw_layer, start_scale)
 		end
 	end
 
+	-- Hive Scum
+	if self._archetype_name == "broker" then
+		local blinder = player_talents.broker_blitz_flash_grenade_improved or player_talents.broker_blitz_flash_grenade
+		local bazooka = player_talents.broker_blitz_missile_launcher
+		local chem_grenade = player_talents.broker_blitz_tox_grenade
+
+		local grenade = (blinder		and (talents.broker_blitz_flash_grenade_improved or talents.broker_blitz_flash_grenade)) or
+						(bazooka		and talents.broker_blitz_missile_launcher) or
+						(chem_grenade	and talents.broker_blitz_tox_grenade)
+
+		if grenade then
+			local grenade_ability = grenade.player_ability.ability
+			-- Blinder Grenades replenish natively (through kills)
+			local replenish_grenade = (player_talents.broker_blitz_flash_grenade_improved == 1) or (player_talents.broker_blitz_flash_grenade == 1)
+			local replenish_buff_logic = replenish_grenade and "broker_passive_blitz_charge_on_kill"
+
+			local broker_grenade = {
+				display_name =	(chem_grenade and 	mod.text_options["text_option_chem_grenade"]) or
+								(bazooka and 	mod.text_options["text_option_missile_launcher"]) or
+												mod.text_options["text_option_blinder"],
+				max_stacks = grenade_ability.max_charges + (player_talents.broker_passive_increased_blitz_ammo or 0),
+				max_duration = nil,
+				decay = true,
+				grenade_ability = true,
+				stack_buff = nil,
+				stacks = 0,
+				progress = 0,
+				timed = false,
+				replenish = replenish_grenade,
+				replenish_buff = replenish_buff_logic or nil,
+				damage_per_stack = nil,
+				damage_boost = nil
+			}
+			resource_info = table.clone(broker_grenade)
+		end
+	end
+
 	if resource_info == nil then
 		resource_info = {
 			display_name = mod.text_options["none"],

--- a/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
+++ b/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
@@ -581,16 +581,21 @@ HudElementblitzbar.init = function (self, parent, draw_layer, start_scale)
 		local bazooka = player_talents.broker_blitz_missile_launcher
 		local chem_grenade = player_talents.broker_blitz_tox_grenade
 
-		local grenade = (blinder		and (talents.broker_blitz_flash_grenade_improved or talents.broker_blitz_flash_grenade)) or
+		local grenade = (blinder		and (
+											(player_talents.broker_blitz_flash_grenade_improved and talents.broker_blitz_flash_grenade_improved) or 
+											(player_talents.broker_blitz_flash_grenade and talents.broker_blitz_flash_grenade)
+										)) or
 						(bazooka		and talents.broker_blitz_missile_launcher) or
 						(chem_grenade	and talents.broker_blitz_tox_grenade)
 
 		if grenade then
 			local grenade_ability = grenade.player_ability.ability
-			-- Blinder Grenades replenish natively (through kills)
-			local replenish_grenade = (player_talents.broker_blitz_flash_grenade_improved == 1) or (player_talents.broker_blitz_flash_grenade == 1)
+			local replenish_grenade = blinder
 			local replenish_buff_logic = replenish_grenade and "broker_passive_blitz_charge_on_kill"
-
+			-- blinder max stacks is always internally +1
+			-- max charges is the correct value
+			-- removing the +blitz section doesnt change anything
+			-- this is a stupid solution
 			local broker_grenade = {
 				display_name =	(chem_grenade and 	mod.text_options["text_option_chem_grenade"]) or
 								(bazooka and 	mod.text_options["text_option_missile_launcher"]) or

--- a/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
+++ b/blitzbar/scripts/mods/blitzbar/UI/UI_elements.lua
@@ -728,6 +728,11 @@ HudElementblitzbar.update = function (self, dt, t, ui_renderer, render_settings,
 			local ability_extension = player_extensions.ability
 			if ability_extension and ability_extension:ability_is_equipped("grenade_ability") then
 				resource_info.stacks = ability_extension:remaining_ability_charges("grenade_ability")
+				
+				-- UGLY AS SHIT manual override for Hives Cum Blinder grenades
+				if resource_info.display_name == mod.text_options["text_option_blinder"] then
+					resource_info.stacks = resource_info.stacks - 1
+				end
 			end
 
 			if not resource_info.replenish then

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
@@ -32,7 +32,11 @@ mod.text_options = table.enum(
 	"text_option_box",
 	"text_option_armour",
 	"text_option_nuke",
-	"text_option_rock"
+	"text_option_rock",
+	-- ARBITRATOR (ADAMANT)
+	"text_option_whistle",
+	"text_option_mine",
+	"text_option_adamant_grenade"
 )
 mod.value_options = table.enum(
 	"none",
@@ -74,7 +78,7 @@ local function get_colors()
 end
 
 local function archetype_options()
-	local archetypes = { "psyker", "veteran", "zealot", "ogryn" }
+	local archetypes = { "psyker", "veteran", "zealot", "ogryn", "adamant" }
 	local defaults = {
 		psyker = {
 			text = mod.text_options["text_option_warp"],
@@ -147,11 +151,36 @@ local function archetype_options()
 			),
 			value = mod.value_options["value_option_stacks"],
 			value_options = mod.value_options
+		},
+		adamant = {
+			text = mod.text_options["text_option_grenades"],
+			text_options = table.enum(
+				mod.text_options["none"],
+				mod.text_options["text_option_blitz"],
+				mod.text_options["text_option_charges"],
+				mod.text_options["text_option_grenades"],
+				mod.text_options["text_option_whistle"],
+				mod.text_options["text_option_mine"],
+				mod.text_options["text_option_adamant_grenade"]
+			),
+			value = mod.value_options["value_option_stacks"],
+			value_options = table.enum(
+				mod.value_options["none"],
+				mod.value_options["value_option_stacks"],
+				mod.value_options["value_option_time_seconds"],
+				mod.value_options["value_option_time_percent"]
+			)
 		}
 	}
 	local archetype_widgets = {}
 	for _, archetype in pairs(archetypes) do
 		local default = defaults[archetype]
+		-- hacky adamant override lol
+		-- ui_adamant and ui_adamant_text are not in colors.lua, so use veteran colors
+		local archetype_for_color = archetype
+		if archetype == "adamant" then
+			archetype_for_color = "veteran"
+		end
 		local widget = {
 			setting_id = archetype .. "_show_gauge",
 			type = "checkbox",
@@ -182,13 +211,13 @@ local function archetype_options()
 				{
 					setting_id = archetype .. "_color_full",
 					type = "dropdown",
-					default_value = "ui_" .. archetype,
+					default_value = "ui_" .. archetype_for_color,
 					options = get_colors()
 				},
 				{
 					setting_id = archetype .. "_color_empty",
 					type = "dropdown",
-					default_value = "ui_" .. archetype .. "_text",
+					default_value = "ui_" .. archetype_for_color .. "_text",
 					options = get_colors()
 				}
 			}

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
@@ -200,8 +200,9 @@ local function archetype_options()
 		local default = defaults[archetype]
 		-- hacky adamant override lol
 		-- ui_adamant and ui_adamant_text are not in colors.lua, so use veteran colors
+		--	are you FUCKING kidding me it happened to hive scum too?
 		local archetype_for_color = archetype
-		if archetype == "adamant" then
+		if (archetype == "adamant") or (archetype == "broker") then
 			archetype_for_color = "veteran"
 		end
 		local widget = {

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
@@ -82,7 +82,7 @@ local function get_colors()
 end
 
 local function archetype_options()
-	local archetypes = { "psyker", "veteran", "zealot", "ogryn", "adamant" }
+	local archetypes = { "psyker", "veteran", "zealot", "ogryn", "adamant", "broker" }
 	local defaults = {
 		psyker = {
 			text = mod.text_options["text_option_warp"],
@@ -174,7 +174,26 @@ local function archetype_options()
 				mod.value_options["value_option_time_seconds"],
 				mod.value_options["value_option_time_percent"]
 			)
-		}
+		},
+		broker = {
+			text = mod.text_options["text_option_grenades"],
+			text_options = table.enum(
+				mod.text_options["none"],
+				mod.text_options["text_option_blitz"],
+				mod.text_options["text_option_charges"],
+				mod.text_options["text_option_grenades"],
+				mod.text_options["text_option_blinder"],
+				mod.text_options["text_option_missile_launcher"],
+				mod.text_options["text_option_chem_grenade"]
+			),
+			value = mod.value_options["value_option_stacks"],
+			value_options = table.enum(
+				mod.value_options["none"],
+				mod.value_options["value_option_stacks"],
+				mod.value_options["value_option_time_seconds"],
+				mod.value_options["value_option_time_percent"]
+			)
+		},
 	}
 	local archetype_widgets = {}
 	for _, archetype in pairs(archetypes) do

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_data.lua
@@ -36,7 +36,11 @@ mod.text_options = table.enum(
 	-- ARBITRATOR (ADAMANT)
 	"text_option_whistle",
 	"text_option_mine",
-	"text_option_adamant_grenade"
+	"text_option_adamant_grenade",
+	-- HIVE SCUM (BROKER)
+	"text_option_blinder",
+	"text_option_missile_launcher",
+	"text_option_chem_grenade"
 )
 mod.value_options = table.enum(
 	"none",

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
@@ -182,6 +182,22 @@ local localizations = {
 	},
 
 	-- ##############################
+	-- #        ARBITRATOR          #
+	-- ##############################
+	text_option_whistle = {
+		--en = "Remote Detonation"
+		en = Localize("loc_talent_ability_detonate")
+	},
+	text_option_mine = {
+		--en = "Voltaic Shock Mine"
+		en = Localize("loc_talent_ability_shock_mine")
+	},
+	text_option_adamant_grenade = {
+		--en = "Arbites Grenade"
+		en = Localize("loc_talent_ability_adamant_grenade")
+	},
+
+	-- ##############################
 	-- #           VALUE            #
 	-- ##############################
 	value_decimals = {
@@ -292,6 +308,9 @@ local localizations = {
 		en = "Ogryn",
 		["zh-cn"] = "欧格林",
 	},
+	adamant = {
+		en = "Arbitrator"
+	},
 	_grenade = {
 		en = "Prefer Grenade",
 		["zh-cn"] = "优先手雷",
@@ -381,20 +400,26 @@ for _, color_name in ipairs(color_names) do
 	localizations[color_name] = { en = cf(color_name) .. display_name(color_name) .. "{#reset()}"}
 end
 
-local archetypes = { "psyker", "veteran", "zealot", "ogryn" }
+local archetypes = { "psyker", "veteran", "zealot", "ogryn", "adamant" }
 local options = { "_grenade", "_gauge_text", "_gauge_value", "_gauge_value_text", "_color_full", "_color_empty"}
 for _, archetype in pairs(archetypes) do
+	-- hacky adamant override lol
+	local archetype_for_color = archetype
+	if archetype == "adamant" then
+		archetype_for_color = "veteran"
+	end
+	
 	localizations[archetype .. "_show_gauge"] = {
-		en = cf("ui_" .. archetype) .. localizations[archetype].en .. "{#reset()}"
+		en = cf("ui_" .. archetype_for_color) .. localizations[archetype].en .. "{#reset()}"
     }
 	for language, _ in pairs(localizations[archetype]) do
-		localizations[archetype .. "_show_gauge"][language] = cf("ui_" .. archetype) .. localizations[archetype][language] .. "{#reset()}"
+		localizations[archetype .. "_show_gauge"][language] = cf("ui_" .. archetype_for_color) .. localizations[archetype][language] .. "{#reset()}"
 	end
 	for _, option in pairs(options) do
 		localizations[archetype .. option] = table.clone(localizations[option])
 		localizations[archetype .. option .. "_description"] = table.clone(localizations[option .. "_description"])
 		for language, _ in pairs(localizations[archetype .. option]) do
-			localizations[archetype .. option][language] = cf("ui_" .. archetype .. "_text") .. localizations[archetype .. option][language] .. "{#reset()}"
+			localizations[archetype .. option][language] = cf("ui_" .. archetype_for_color .. "_text") .. localizations[archetype .. option][language] .. "{#reset()}"
 			localizations[archetype .. option .. "_description"][language] = localizations[archetype .. option .. "_description"][language]
 		end
 	end

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
@@ -185,16 +185,16 @@ local localizations = {
 	-- #        ARBITRATOR          #
 	-- ##############################
 	text_option_whistle = {
-		--en = "Remote Detonation"
-		en = Localize("loc_talent_ability_detonate")
+		en = "Dog"
+		--en = Localize("loc_talent_ability_detonate")
 	},
 	text_option_mine = {
-		--en = "Voltaic Shock Mine"
-		en = Localize("loc_talent_ability_shock_mine")
+		en = "Mine"
+		--en = Localize("loc_talent_ability_shock_mine")
 	},
 	text_option_adamant_grenade = {
-		--en = "Arbites Grenade"
-		en = Localize("loc_talent_ability_adamant_grenade")
+		en = "Impact"
+		--en = Localize("loc_talent_ability_adamant_grenade")
 	},
 
 	-- ##############################

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
@@ -198,6 +198,22 @@ local localizations = {
 	},
 
 	-- ##############################
+	-- #         HIVE SCUM          #
+	-- ##############################
+	text_option_blinder = {
+		en = "Blinder"
+		--en = Localize("loc_talent_broker_blitz_flash_grenade")
+	},
+	text_option_missile_launcher = {
+		en = "Bazooka"
+		--en = Localize("loc_talent_broker_blitz_missile_launcher")
+	},
+	text_option_chem_grenade = {
+		en = "Chem"
+		--en = Localize("loc_talent_broker_blitz_tox_grenade")
+	},
+
+	-- ##############################
 	-- #           VALUE            #
 	-- ##############################
 	value_decimals = {

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
@@ -416,12 +416,12 @@ for _, color_name in ipairs(color_names) do
 	localizations[color_name] = { en = cf(color_name) .. display_name(color_name) .. "{#reset()}"}
 end
 
-local archetypes = { "psyker", "veteran", "zealot", "ogryn", "adamant" }
+local archetypes = { "psyker", "veteran", "zealot", "ogryn", "adamant", "broker" }
 local options = { "_grenade", "_gauge_text", "_gauge_value", "_gauge_value_text", "_color_full", "_color_empty"}
 for _, archetype in pairs(archetypes) do
 	-- hacky adamant override lol
 	local archetype_for_color = archetype
-	if archetype == "adamant" then
+	if (archetype == "adamant") or (archetype == "broker") then
 		archetype_for_color = "veteran"
 	end
 	

--- a/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
+++ b/blitzbar/scripts/mods/blitzbar/blitzbar_localization.lua
@@ -327,6 +327,9 @@ local localizations = {
 	adamant = {
 		en = "Arbitrator"
 	},
+	broker = {
+		en = "Hive Scum"
+	},
 	_grenade = {
 		en = "Prefer Grenade",
 		["zh-cn"] = "优先手雷",


### PR DESCRIPTION
Not perfect but a start for supporting the new class.
- Added Arbitrator defaults to the UI Elements
    - Checks for grenade replenishment (Remote Detonation Blitz or when using Lone Wolf)
    - Checks for increased max capacity (when using Lone Wolf)
- Added mod options for Arbitrator grenades
- Added `en` localizations for Arbitrator grenade names
- Since `ui_adamant` and `ui_adamant_text` don't exist in `color.lua`, I made a hacky solution to default to the vet ui colors >_> 

Issues I had:
- When using Lone Wolf and the Arbites Grenade:
    - the segments are not centered on the blitz bar when placed vertically
    - ~~total segments are correct but they count down incorrectly (first throw doesn't decrease the amount of grenades left)~~
- ~~When using Lone Wolf, there isn't a replenish timer even though there should be~~
- Blitz bar would not refresh (segment amount, name of grenade, etc.) when swapping loadouts without opening the Talents tab
- Does not add segments when in Maelstrom condition Enhanced Blitz (G)

There might be more issues I didn't catch since I don't use this mod much. It mostly seemed fine in the Meat Grinder, though.

Also I worked off the Nexus version, so sorry if there's any errors from copying the changes from my local version to this repo. If you want to see that version, let me know so I can send it over.